### PR TITLE
Add Jest setup and toggleArticles DOM tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "octavioadvogado",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^30.0.0",
+    "jsdom": "^26.0.0"
+  }
+}

--- a/tests/toggleArticles.test.js
+++ b/tests/toggleArticles.test.js
@@ -1,0 +1,58 @@
+const fs = require('fs');
+const path = require('path');
+const { JSDOM } = require('jsdom');
+
+const html = fs.readFileSync(path.join(__dirname, '..', 'contratorural'), 'utf8');
+
+describe('toggleArticles', () => {
+  let dom;
+  let document;
+  let button;
+  let container;
+
+  beforeEach(async () => {
+    dom = new JSDOM(html, {
+      runScripts: 'dangerously',
+      resources: 'usable'
+    });
+
+    await new Promise((resolve) => {
+      dom.window.document.addEventListener('DOMContentLoaded', resolve);
+    });
+
+    document = dom.window.document;
+
+    button = document.createElement('button');
+    button.innerHTML = `
+      <span class="button-text">✨ Ver Artigos Pertinentes</span>
+      <div class="loader hidden"></div>
+    `;
+
+    container = document.createElement('div');
+    container.id = 'articles-test';
+
+    document.body.appendChild(button);
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    dom.window.close();
+  });
+
+  test('adds show class and updates button text when expanding', async () => {
+    await dom.window.toggleArticles('Lei do Inquilinato', 'articles-test', button);
+
+    expect(container.classList.contains('show')).toBe(true);
+    expect(button.querySelector('.button-text').textContent).toBe('Ocultar Artigos');
+  });
+
+  test('removes show class and restores original button text when toggled again', async () => {
+    const originalText = button.querySelector('.button-text').textContent;
+
+    await dom.window.toggleArticles('Lei do Inquilinato', 'articles-test', button);
+    await dom.window.toggleArticles('Lei do Inquilinato', 'articles-test', button);
+
+    expect(container.classList.contains('show')).toBe(false);
+    expect(button.querySelector('.button-text').textContent).toBe(originalText);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a local unit test setup for verifying the UI behavior of `toggleArticles` using a DOM simulation so regressions can be caught automatically.

### Description
- Add `package.json` with a `test` script (`"test": "jest"`) and `devDependencies` for `jest` and `jsdom` to enable running DOM-oriented unit tests with Jest.
- Add `tests/toggleArticles.test.js` which loads the existing `contratorural` HTML into `jsdom`, creates a button and an article container, and calls `toggleArticles` from the page script.
- The tests assert that calling `toggleArticles` adds the `show` class and changes the button text to `Ocultar Artigos`, and that calling it again removes the `show` class and restores the original button text.

### Testing
- Ran `npm install`, which failed with `403 Forbidden` from the npm registry so dependencies could not be installed.
- Ran `npm test`, which failed because `jest` was not available in the environment (`sh: 1: jest: not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c616e31d6483229e699271e3d4e020)